### PR TITLE
Check path variables for cartridges in package.json + added output channel for debugging

### DIFF
--- a/src/lib/CartridgeHelper.ts
+++ b/src/lib/CartridgeHelper.ts
@@ -56,12 +56,12 @@ export const toCardridge = (projectFile: string, activeFile?: string): Promise<C
  * @param packageFile The path to the package file.
  */
 export const getPathsCartridges = (workspaceRoot, packageFile): Promise<string[]> => {
-	return new Promise((resolve) => {
+	return new Promise((resolve, reject) => {
 		pathExists(packageFile).then(packageExists => {
 			if (packageExists) {
 				readFile(packageFile, 'UTF-8', (error, data) => {
 					if (error) {
-						resolve();
+						reject('Error reading package file.')
 					}
 
 					const packageFileObject = JSON.parse(data);
@@ -83,10 +83,11 @@ export const getPathsCartridges = (workspaceRoot, packageFile): Promise<string[]
 												absolute: true,
 												ignore: ['**/node_modules/**', '**/.git/**']
 											}, (globError, projectFiles: string[]) => {
+												if (globError) { reject(globError); };
 												resolvePathProjects(projectFiles);
 											});
 										} else {
-											resolve([]);
+											resolvePathProjects([]);
 										}
 									});
 								}));

--- a/src/lib/CartridgeHelper.ts
+++ b/src/lib/CartridgeHelper.ts
@@ -72,7 +72,7 @@ export const getPathsCartridges = (workspaceRoot, packageFile): Promise<string[]
 
 						paths.forEach(function (path) {
 							if (typeof path === 'string') {
-								promises.push(new Promise((resolvePathProjects) => {
+								promises.push(new Promise((resolvePathProjects, rejectPathProjects) => {
 									exists(join(workspaceRoot, path), packagePathExists => {
 										if (packagePathExists) {
 											glob('**/.project', {
@@ -83,7 +83,7 @@ export const getPathsCartridges = (workspaceRoot, packageFile): Promise<string[]
 												absolute: true,
 												ignore: ['**/node_modules/**', '**/.git/**']
 											}, (globError, projectFiles: string[]) => {
-												if (globError) { reject(globError); };
+												if (globError) { rejectPathProjects(globError); };
 												resolvePathProjects(projectFiles);
 											});
 										} else {
@@ -96,6 +96,8 @@ export const getPathsCartridges = (workspaceRoot, packageFile): Promise<string[]
 
 						Promise.all(promises).then(result => {
 							resolve([].concat(result.concat.apply([], result)));
+						}, error => {
+							reject('Exception processing package paths: ' + error);
 						});
 					} else {
 						resolve([]);

--- a/src/lib/CartridgeHelper.ts
+++ b/src/lib/CartridgeHelper.ts
@@ -91,17 +91,10 @@ export const getPathsCartridges = (workspaceRoot, packageFile): Promise<string[]
 									});
 								}));
 							}
-
 						});
 
 						Promise.all(promises).then(result => {
-							let conjoinedArray: string[] = [];
-
-							for (let i = 0; i < result.length; i++) {
-								conjoinedArray = conjoinedArray.concat(result[i]);
-							}
-
-							resolve(conjoinedArray);
+							resolve([].concat(result.concat.apply([], result)));
 						});
 					} else {
 						resolve([]);

--- a/src/providers/CartridgesView.ts
+++ b/src/providers/CartridgesView.ts
@@ -180,6 +180,8 @@ export class CartridgesView implements TreeDataProvider<CartridgeItem> {
 				} else {
 					resolve([CartridgeItem.NoCartridges]);
 				}
+			}, error => {
+				cartridgeViewOutputChannel.appendLine('Exception when trying to fetch workspace cartridges: ' + error);
 			});
 		});
 	}

--- a/src/server/uploadServer.ts
+++ b/src/server/uploadServer.ts
@@ -79,7 +79,10 @@ function fileWatcher(config, cartRoot: string) {
 			persistent: true,
 			ignoreInitial: true,
 			followSymlinks: false,
-			awaitWriteFinish: true
+			awaitWriteFinish: {
+				stabilityThreshold: 1000,
+				pollInterval: 100
+			}
 		});
 
 		watcher.on('change', path => observer.next(['upload', path]));

--- a/src/server/uploadServer.ts
+++ b/src/server/uploadServer.ts
@@ -80,7 +80,7 @@ function fileWatcher(config, cartRoot: string) {
 			ignoreInitial: true,
 			followSymlinks: false,
 			awaitWriteFinish: {
-				stabilityThreshold: 1000,
+				stabilityThreshold: 300,
 				pollInterval: 100
 			}
 		});

--- a/src/server/uploadServer.ts
+++ b/src/server/uploadServer.ts
@@ -36,7 +36,7 @@ export function readConfigFile(configFilename: string): Observable<DavOptions> {
 		});
 
 		return () => {
-			chunks = [];
+			chunks = <any>null;
 			stream.close();
 		};
 	});

--- a/src/server/uploadServer.ts
+++ b/src/server/uploadServer.ts
@@ -5,19 +5,17 @@ import 'rxjs/add/observable/merge';
 import 'rxjs/add/operator/concat';
 import 'rxjs/add/operator/retryWhen';
 
-
 import { OutputChannel, workspace } from 'vscode';
 import { default as WebDav, DavOptions } from './WebDav';
-import { getDirectoriesSync } from '../lib/FileHelper'
+import { getDirectoriesSync } from '../lib/FileHelper';
 import { dirname, join } from 'path';
 import { createReadStream } from 'fs';
 import * as chokidar from 'chokidar';
 
-
 export function readConfigFile(configFilename: string): Observable<DavOptions> {
 	return Observable.create(observer => {
-		var stream = createReadStream(configFilename);
-		let chunks: any[] = [];
+		const stream = createReadStream(configFilename);
+		let chunks: Buffer[] = [];
 
 		// Listen for data
 		stream.on('data', chunk => {
@@ -38,9 +36,9 @@ export function readConfigFile(configFilename: string): Observable<DavOptions> {
 		});
 
 		return () => {
-			chunks = <any>null;
-			stream.close()
-		}
+			chunks = [];
+			stream.close();
+		};
 	});
 }
 
@@ -53,8 +51,10 @@ export function getWebDavClient(config: DavOptions, outputChannel: OutputChannel
 			version: config['code-version'] || config.version,
 			root: rootDir
 		}, config.debug ?
-				(...msgs) => { outputChannel.appendLine(`${msgs.join(' ')}`) } :
-				() => { }
+				(...msgs) => { outputChannel.appendLine(`${msgs.join(' ')}`); } :
+				() => {
+					// DO NOTHING
+				}
 		);
 		observer.next(webdav);
 	});
@@ -62,11 +62,12 @@ export function getWebDavClient(config: DavOptions, outputChannel: OutputChannel
 
 function fileWatcher(config, cartRoot: string) {
 	return Observable.create(observer => {
-		var cartridges;
+		let cartridges;
+
 		if (config.cartridge && config.cartridge.length) {
 			cartridges = config.cartridge;
 		} else {
-			cartridges = getDirectoriesSync(cartRoot)
+			cartridges = getDirectoriesSync(cartRoot);
 		}
 
 		let watcher = chokidar.watch(null, {
@@ -100,16 +101,16 @@ function fileWatcher(config, cartRoot: string) {
 			watcher.close();
 			watcher = null;
 			cartridges = null;
-		}
+		};
 	});
 }
 
-const uploadCartridges = (webdav: WebDav, outputChannel: OutputChannel, config: any, cartRoot: string) => {
-	var cartridges;
+const uploadCartridges = (webdav: WebDav, outputChannel: OutputChannel, config: ({ cartridge }), cartRoot: string) => {
+	let cartridges;
 	if (config.cartridge && config.cartridge.length) {
 		cartridges = config.cartridge;
 	} else {
-		cartridges = getDirectoriesSync(cartRoot)
+		cartridges = getDirectoriesSync(cartRoot);
 	}
 
 	const toUpload = cartridges
@@ -124,10 +125,9 @@ const uploadCartridges = (webdav: WebDav, outputChannel: OutputChannel, config: 
 				.uploadCartridges(dirToUpload, notify, { isCartridge: true });
 		});
 	return Observable.merge(...toUpload, 3).concat(Promise.resolve(1));
-}
+};
 
-
-function uploadAndWatch(webdav: WebDav, outputChannel: OutputChannel, config: any, rootDir: string) {
+function uploadAndWatch(webdav: WebDav, outputChannel: OutputChannel, config: ({ cartridge, version }), rootDir: string) {
 	return webdav.dirList(rootDir)
 		.do(() => {
 			outputChannel.appendLine(`Connection validated successfully`);
@@ -174,13 +174,14 @@ function uploadAndWatch(webdav: WebDav, outputChannel: OutputChannel, config: an
 					} else {
 						throw Error('Unknown action');
 					}
-				}, 5)
-		})
+				}, 5);
+		});
 }
+
 export function init(configFilename: string, outputChannel: OutputChannel) {
 	let conf;
 	return readConfigFile(configFilename).flatMap(config => {
-		var rootDir = dirname(configFilename);
+		let rootDir = dirname(configFilename);
 		if (config.root) {
 			rootDir = join(rootDir, config.root);
 		}
@@ -188,7 +189,7 @@ export function init(configFilename: string, outputChannel: OutputChannel) {
 		outputChannel.appendLine(`Using directory "${rootDir}" as cartridges root`);
 		return getWebDavClient(config, outputChannel, rootDir);
 	}).flatMap(webdav => {
-		var retryCounter = 0;
+		let retryCounter = 0;
 		return uploadAndWatch(webdav, outputChannel, conf, webdav.config.root)
 			.retryWhen(function (errors) {
 				// retry for some errors, end the stream with an error for others
@@ -206,5 +207,5 @@ export function init(configFilename: string, outputChannel: OutputChannel) {
 				retryCounter = 0;
 				conf = null;
 			});
-	})
+	});
 }


### PR DESCRIPTION
With the new mobile first setup referencing the main catridge in the package "paths" parameter I have added support for this. This allows you to browse the main sfcc cartridge in a different workspace when creating a plugin for example.

Also added an output channel to allow bugreports to include output.