### PR TITLE
Change to statSync so symlink dirs can be uploaded

### DIFF
--- a/src/lib/FileHelper.ts
+++ b/src/lib/FileHelper.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
  * @param srcpath The path to look in for directories
  */
 export function getDirectoriesSync(srcpath: string): string[] {
-	return fs.readdirSync(srcpath).filter(file => fs.lstatSync(path.join(srcpath, file)).isDirectory());
+	return fs.readdirSync(srcpath).filter(file => fs.statSync(path.join(srcpath, file)).isDirectory());
 }
 
 /**


### PR DESCRIPTION
Projects that don't conform to the standard of placing all cartridges in the path need to have the ability to upload all of the cartridges. 

A solution proposed is to use symlinks so that the project appears to conform to the standard. 

The only issue with the solution is that this extension doesn't pick up the symlink directories. Changing lstatSync to statSync will fix the issue