### PR TITLE
Feature/cartridge resolution

### DIFF
--- a/src/providers/Uploader.ts
+++ b/src/providers/Uploader.ts
@@ -62,7 +62,7 @@ export default class Uploader {
 		return workspace.getConfiguration('extension.prophet').get('ignore.list', ['node_modules', '\\.git', '\\.zip$']);
 	}
 
-	askCleanCartridge(fileNamesOnSandbox: string[], cartridgesToUpload: string[]): Promise<string[]> {
+	async askCleanCartridge(fileNamesOnSandbox: string[], cartridgesToUpload: string[]): Promise<string[]> {
 		const cartridgesNamesToUpload = cartridgesToUpload.map(cartridge => basename(cartridge));
 
 		const extraOnSB = diff(cartridgesNamesToUpload, fileNamesOnSandbox).filter(name => {
@@ -76,43 +76,34 @@ export default class Uploader {
 
 
 		if (extraOnSB.length === 0) {
-			return Promise.resolve(fileNamesOnSandbox);
+			return fileNamesOnSandbox;
 		} else if (removeFilesMode) {
 			if (removeFilesMode === 'remove') {
-				return Promise.resolve(fileNamesOnSandbox);
+				return fileNamesOnSandbox;
 			} else {
-				return Promise.resolve(cartridgesNamesToUpload);
+				return cartridgesNamesToUpload;
 			}
 		} else {
-			return new Promise((resolve, reject) => {
-				window.showWarningMessage(`Your sandbox has extra cartridge/s. "${extraOnSB.join('", "')}". What would you like to do?`,
-					'Remove All Always', 'Leave All Always', 'Remove All', 'Leave All')
-					.then(response => {
-						if (response) {
-
-							switch (response) {
-								case 'Remove All Always':
-									resolve(fileNamesOnSandbox);
-									removeFilesMode = "remove";
-									break;
-								case 'Leave All Always':
-									resolve(cartridgesNamesToUpload);
-									removeFilesMode = "leave"
-									break;
-
-								case 'Remove All':
-									resolve(fileNamesOnSandbox);
-									break;
-								default:
-									resolve(cartridgesNamesToUpload);
-									break;
-							}
-						} else {
-							resolve(cartridgesNamesToUpload);
-						}
-					}, reject);
-			})
-
+			const response = await window.showWarningMessage(`Your sandbox has extra cartridge/s. "${extraOnSB.join('", "')}". What would you like to do?`,
+			'Remove All Always', 'Leave All Always', 'Remove All', 'Leave All');
+			
+			if (response) {
+				
+				switch (response) {
+					case 'Remove All Always':
+					removeFilesMode = "remove";
+					return fileNamesOnSandbox;
+					case 'Leave All Always':
+					removeFilesMode = "leave";
+					return cartridgesNamesToUpload;
+					case 'Remove All':
+					return fileNamesOnSandbox;
+					default:
+					return cartridgesNamesToUpload;
+				}
+			} else {
+				return cartridgesNamesToUpload;
+			}
 		}
 	}
 	/**

--- a/src/providers/Uploader.ts
+++ b/src/providers/Uploader.ts
@@ -84,6 +84,16 @@ export default class Uploader {
 				return cartridgesNamesToUpload;
 			}
 		} else {
+			const config = await getDWConfig(this.workspaceFolders);
+
+			if(config.cartrigeResolution === 'remove') {
+				removeFilesMode = "remove";
+				return fileNamesOnSandbox;
+			} else if (config.cartrigeResolution === 'leave') {
+				removeFilesMode = "leave";
+				return cartridgesNamesToUpload;
+			}
+
 			const response = await window.showWarningMessage(`Your sandbox has extra cartridge/s. "${extraOnSB.join('", "')}". What would you like to do?`,
 			'Remove All Always', 'Leave All Always', 'Remove All', 'Leave All');
 			

--- a/src/providers/Uploader.ts
+++ b/src/providers/Uploader.ts
@@ -84,6 +84,7 @@ export default class Uploader {
 				return cartridgesNamesToUpload;
 			}
 		} else {
+			// Grab the configuration from the dw.json file
 			const config = await getDWConfig(this.workspaceFolders);
 
 			if(config.cartrigeResolution === 'remove') {
@@ -94,6 +95,7 @@ export default class Uploader {
 				return cartridgesNamesToUpload;
 			}
 
+			// Prompt the user for his preferred action
 			const response = await window.showWarningMessage(`Your sandbox has extra cartridge/s. "${extraOnSB.join('", "')}". What would you like to do?`,
 			'Remove All Always', 'Leave All Always', 'Remove All', 'Leave All');
 			

--- a/src/server/WebDav.ts
+++ b/src/server/WebDav.ts
@@ -35,7 +35,8 @@ export interface DavOptions {
 	password: string,
 	version: string,
 	root: string,
-	debug?: boolean
+	debug?: boolean,
+	cartrigeResolution: 'ask'|'leave'|'remove'
 }
 
 function getMatches(string: string, regex: RegExp, index = 1) {

--- a/syntaxes/dw.schema.json
+++ b/syntaxes/dw.schema.json
@@ -47,6 +47,11 @@
             "type":"boolean",
             "default": false,
             "description": "Enable more verbose logging"
+        },
+        "cartridgeResolution" : {
+            "type":"string",
+            "default": "ask",
+            "description": "Leaves all the cartridges instead of asking"
         }
     },
     "dependencies": {


### PR DESCRIPTION
Hello,

I came up with the idea of being able to define in the `dw.json` file if you want to leave all the cartridges that are already there, or to remove them instead of having to select an option on the vscode prompt that is presented currently. This feature falls back to the current behaviour of prompting the user for an option.

The new attribute defined would be named `cartrigeResolution` and it could have the values `leave`, `remove`, `ask`, or just not be set.