### PR TITLE
Isml linter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,11 +60,24 @@
                 "ansi-wrap": "0.1.0"
             }
         },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
         "ansi-wrap": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
             "dev": true
+        },
+        "app-root-path": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.2.1.tgz",
+            "integrity": "sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA=="
         },
         "append-buffer": {
             "version": "1.0.2",
@@ -226,6 +239,16 @@
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
         "cli": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
@@ -301,6 +324,19 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "colors": {
             "version": "1.3.2",
@@ -449,7 +485,8 @@
         "domelementtype": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "optional": true
         },
         "domhandler": {
             "version": "2.3.0",
@@ -573,8 +610,7 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "event-stream": {
             "version": "3.3.4",
@@ -594,7 +630,8 @@
         "exit": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "optional": true
         },
         "extend": {
             "version": "3.0.2",
@@ -1059,8 +1096,7 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbols": {
             "version": "1.0.0",
@@ -1253,6 +1289,16 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
             "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "isml-linter": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/isml-linter/-/isml-linter-5.5.1.tgz",
+            "integrity": "sha512-3k3eCNIHnhX20EZgWMZJ8+xUHA1Z9usX8ARo5KYqH09N6zcKVwYXTc/HGLj8OMbRJohlUW+BEFC98fJLi4/4sQ==",
+            "requires": {
+                "app-root-path": "^2.1.0",
+                "chalk": "^2.4.2",
+                "readdir": "^0.1.0"
+            }
         },
         "isstream": {
             "version": "0.1.2",
@@ -1751,6 +1797,11 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
+        "q": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
+            "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ="
+        },
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -1781,6 +1832,14 @@
                 "inherits": "~2.0.1",
                 "isarray": "0.0.1",
                 "string_decoder": "~0.10.x"
+            }
+        },
+        "readdir": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/readdir/-/readdir-0.1.0.tgz",
+            "integrity": "sha512-6ooimObbcBEgROguDY083rVL7EKMWWRYEujAld28oinI3mflpfXJVBGtFNjtRnpYFjuD2RGayOmQJnVEGPyXVQ==",
+            "requires": {
+                "q": "~1.0.1"
             }
         },
         "remove-bom-buffer": {
@@ -2040,7 +2099,6 @@
             "version": "5.4.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
             "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-            "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     },
     "dependencies": {
         "htmlhint": "^0.11.0",
+        "isml-linter": "^5.5.1",
         "js-beautify": "^1.9.0",
         "request": "^2.88.0",
         "rxjs": "^5.5.10",


### PR DESCRIPTION
This PR introduces the [Isml Linter]( https://www.npmjs.com/package/isml-linter) tool, which parses the template and builds a full ISML DOM, allowing the usage of powerful rules. There is a [PR to SFRA](https://github.com/SalesforceCommerceCloud/storefront-reference-architecture/pull/430#issuecomment-484597688) which should be merged soon.

I got some problem while running Prophet locally, probably due to a misconfigured launch.json file, so I need some help there, if anyone is available.

Please check the npm package for all available rules and configs. Hope this PR is useful!

Thanks!