### PR TITLE
Centralised config handling with password complementation

### DIFF
--- a/src/providers/LogsView.ts
+++ b/src/providers/LogsView.ts
@@ -17,11 +17,11 @@ import {
 } from 'vscode';
 
 import { join, basename } from 'path';
-import { default as WebDav, readConfigFile } from '../server/WebDav';
+import { default as WebDav } from '../server/WebDav';
 import { DOMParser } from 'xmldom';
 import { Observable, Subject } from 'rxjs';
 import timeago from 'timeago.js';
-import { getCartridgesFolder } from '../lib/FileHelper';
+import { getCartridgesFolder, getConfig } from '../lib/FileHelper';
 
 
 const domParser = new DOMParser();
@@ -105,7 +105,7 @@ export class LogsView implements TreeDataProvider<LogItem> {
 			return dwConfig$
 				.do(() => { }, undefined, () => { end$.next(); end$.complete() })
 				.flatMap((dwConfig) => {
-					return readConfigFile(dwConfig.fsPath);
+					return getConfig(dwConfig.fsPath);
 				})
 				.flatMap((davOptins) => {
 					return new Observable((observer) => {


### PR DESCRIPTION
Currently you can enter you password when not in `dw.json`, but it will not work for the log view as it will not prompt for the password. This PR resolves this via putting the reading of the config & the completion with user prompt into a central place.