### PR TITLE
Adds new `\\*.git$` ignore pattern to resolve odd `isml.git`, `js.git`, `scss.git` etc upload / watch issues

### DIFF
--- a/src/providers/Uploader.ts
+++ b/src/providers/Uploader.ts
@@ -59,7 +59,7 @@ export default class Uploader {
 		return !!workspace.getConfiguration('extension.prophet').get('upload.enabled');
 	}
 	getIgnoreList(): string[] {
-		return workspace.getConfiguration('extension.prophet').get('ignore.list', ['node_modules', '\\.git', '\\.zip$']);
+		return workspace.getConfiguration('extension.prophet').get('ignore.list', ['node_modules', '\\.git', '\\.zip$', '\\*.git$']);
 	}
 
 	async askCleanCartridge(fileNamesOnSandbox: string[], cartridgesToUpload: string[]): Promise<string[]> {


### PR DESCRIPTION
Fix possible VS Code issue where Prophet Debugger is Uploading / Watching files that do not exist that end in `.git`

This seemed to impact all files Prophet Debugger managed.  This fix adds a new default ignore pattern `\\*.git$` which has been tested to resolve the reported issue.

- [X] Fixes #208
- [X] Passing `npm test`