### PR TITLE
Added client id and client secret

### DIFF
--- a/syntaxes/dw.schema.json
+++ b/syntaxes/dw.schema.json
@@ -63,7 +63,17 @@
                 "leave"
             ],
             "description": "Leaves all the cartridges instead of asking"
-        }
+        },
+        "client-id": {
+            "type":"string",
+            "default": "aaaaaaaaaaaaaaaaaaa",
+            "description": "Client id for On-Demand Sandbox API"
+        },
+        "client-secret": {
+            "type":"string",
+            "default": "passw0rd!",
+            "description": "Client secret for On-Demand Sandbox API"
+        },
     },
     "dependencies": {
         "p12": [


### PR DESCRIPTION
The Open Commerce API requires that each client have a client ID. As SFCC is trying to make OCAPI a way to communicate with a sandbox a client id and client secret is required. Packages such SFCC-CI uses them to authenticate every rest request.  