### PR TITLE
feat: add configuration flag to disable linting on back end js  #228

### DIFF
--- a/src/server/ScriptServer.ts
+++ b/src/server/ScriptServer.ts
@@ -8,6 +8,7 @@ import {
 } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { getIndexes, activateIndexes } from './scriptServer/features/indexes';
+import { workspace } from 'vscode';
 
 // Create a connection for the server. The connection uses Node's IPC as a transport
 const connection: IConnection = createConnection(new IPCMessageReader(process), new IPCMessageWriter(process));
@@ -43,9 +44,12 @@ connection.onInitialized(() => {
 	import('./scriptServer/features/competitions').then(competitions => {
 		competitions.activate(connection, documents);
 	});
-	import('./scriptServer/features/diagnostics').then(linting => {
-		linting.activate(connection, documents);
-	});
+	const lintingDisabled = workspace.getConfiguration('extension.prophet').get('disable.linting.back-end-js') as boolean;
+	if (!lintingDisabled) {
+		import('./scriptServer/features/diagnostics').then(linting => {
+			linting.activate(connection, documents);
+		});
+	}
 });
 
 


### PR DESCRIPTION
Hey its me again!. 

My team and I were having problem with the linting, if you let me add a consideration, I think is out of scope for prophet since eslint allows to do it in a configurable way. Also there is an issue #228

Added a flag before the linting was imported in the server to check if in the configuration exist a boolean with key `disable.linting.back-end-js`. I considered as disable flag to have it as default enabled to not change normal behavior. 

Thanks again! 😃