### PR TITLE
'dw.schema.json' parse error fix

### DIFF
--- a/syntaxes/dw.schema.json
+++ b/syntaxes/dw.schema.json
@@ -73,7 +73,7 @@
             "type":"string",
             "default": "passw0rd!",
             "description": "Client secret for On-Demand Sandbox API"
-        },
+        }
     },
     "dependencies": {
         "p12": [


### PR DESCRIPTION
There is a fix for an error in JSON schema file.

![image](https://user-images.githubusercontent.com/64134741/79968174-6dc8e800-8498-11ea-94bc-6eb43ed7569e.png)
