### PR TITLE
Fixing the old links

### DIFF
--- a/package.json
+++ b/package.json
@@ -317,8 +317,8 @@
             },
             {
                 "command": "extension.prophet.command.open.xchange",
-                "title": "Prophet: Open Xchange",
-                "description": "Open Xchange"
+                "title": "Prophet: Open Dev Center Discussion Groups",
+                "description": "Open Dev Center Discussion Groups"
             }
         ],
         "jsonValidation": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,12 +212,12 @@ export function activate(context: ExtensionContext) {
 
 	context.subscriptions.push(
 		commands.registerCommand('extension.prophet.command.open.documentation', () => {
-			commands.executeCommand('vscode.open', Uri.parse('https://documentation.demandware.com'));
+			commands.executeCommand('vscode.open', Uri.parse('https://documentation.b2c.commercecloud.salesforce.com/'));
 		})
 	);
 	context.subscriptions.push(
 		commands.registerCommand('extension.prophet.command.open.xchange', () => {
-			commands.executeCommand('vscode.open', Uri.parse('https://xchange.demandware.com'));
+			commands.executeCommand('vscode.open', Uri.parse('https://developer.commercecloud.com/s/discussion-groups'));
 		})
 	);
 


### PR DESCRIPTION
Contains the following changes:
- Fixing the documentation link (should automatically go to the DOC1 docs)
- Replacing xchange link with the developer center discussion groups link