### PR TITLE
Removed logic that prevents debugging on files in front-end side folders

### DIFF
--- a/src/mockDebug.ts
+++ b/src/mockDebug.ts
@@ -242,18 +242,6 @@ class ProphetDebugSession extends LoggingDebugSession {
 			this._breakPoints.set(path, []);
 		}
 
-		if (scriptPath.includes('/default/js/') || scriptPath.includes('/cartridge/js/')) {
-			response.body = {
-				breakpoints: []
-			};
-			response.success = false;
-			response.message = "Unable to set breakpoint to non backend file";
-
-			this.logError(response.message);
-
-			return this.sendResponse(response);
-		}
-
 		const scriptBrks = this._breakPoints.get(path) || [];
 
 		// remove if unexist


### PR DESCRIPTION
- It is possible to create a file that can be used on both sides and I think with this logic we are blocking that.
 I don't see any benefit for this blocking logic and just proposing to remove this.